### PR TITLE
Use GroupVersionKind to test for "is known to server"

### DIFF
--- a/pkg/kubecfg/validate.go
+++ b/pkg/kubecfg/validate.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 
@@ -34,34 +35,40 @@ type ValidateCmd struct {
 }
 
 func (c ValidateCmd) Run(apiObjects []*unstructured.Unstructured, out io.Writer) error {
-	knownResources := map[string]sets.String{}
-
-	serverResourceList, err := c.Discovery.ServerResources()
-	if err != nil {
-		return err
-	}
-	for _, rl := range serverResourceList {
-		knownResources[rl.GroupVersion] = sets.String{}
-		for _, r := range rl.APIResources {
-			knownResources[rl.GroupVersion][r.Name] = sets.Empty{}
+	knownGVKs := sets.NewString()
+	gvkExists := func(gvk schema.GroupVersionKind) bool {
+		if knownGVKs.Has(gvk.String()) {
+			return true
 		}
+		gv := gvk.GroupVersion()
+		rls, err := c.Discovery.ServerResourcesForGroupVersion(gv.String())
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Debugf("ServerResourcesForGroupVersion(%q) returned unexpected error %v", gv, err)
+			}
+			return false
+		}
+		for _, rl := range rls.APIResources {
+			knownGVKs.Insert(gv.WithKind(rl.Kind).String())
+		}
+		return knownGVKs.Has(gvk.String())
 	}
 
 	hasError := false
 
 	for _, obj := range apiObjects {
-		resName := utils.ResourceNameFor(c.Discovery, obj)
-		desc := fmt.Sprintf("%s %s", resName, utils.FqName(obj))
+		desc := fmt.Sprintf("%s %s", utils.ResourceNameFor(c.Discovery, obj), utils.FqName(obj))
 		log.Info("Validating ", desc)
 
-		gv := obj.GroupVersionKind().GroupVersion()
+		gvk := obj.GroupVersionKind()
+		gv := gvk.GroupVersion()
 
 		var allErrs []error
 
 		schema, err := utils.NewSwaggerSchemaFor(c.Discovery, gv)
 		if err != nil {
-			if _, known := knownResources[gv.String()][resName]; errors.IsNotFound(err) && known {
-				log.Warnf("Skipping validation of known resource %s %s that lacks a registered schema", gv, resName)
+			if errors.IsNotFound(err) && gvkExists(gvk) {
+				log.Infof(" No schema found for %s, skipping validation", gvk)
 				continue
 			}
 			allErrs = append(allErrs, fmt.Errorf("Unable to fetch schema: %v", err))


### PR DESCRIPTION
FYI, (known/success) output looks like:
```
INFO  Validating issuers mynamespace.myname
INFO  No schema found for certmanager.k8s.io/v1alpha1, Kind=Issuer, skipping validation
```

Unknown/failure output (note "certmanxager" typo in input) looks like:
```
INFO  Validating issuer mynamespace.myname
ERROR Error in issuer mynamespace.myname: Unable to fetch schema: API version: certmanxager.k8s.io/v1alpha1 is not supported by the server. Use one of: [apiregistration.k8s.io/v1beta1 extensions/v1beta1 apps/v1 apps/v1beta2 apps/v1beta1 events.k8s.io/v1beta1 authentication.k8s.io/v1 authentication.k8s.io/v1beta1 authorization.k8s.io/v1 authorization.k8s.io/v1beta1 autoscaling/v1 autoscaling/v2beta1 batch/v1 batch/v1beta1 certificates.k8s.io/v1beta1 networking.k8s.io/v1 policy/v1beta1 rbac.authorization.k8s.io/v1 rbac.authorization.k8s.io/v1beta1 storage.k8s.io/v1 storage.k8s.io/v1beta1 admissionregistration.k8s.io/v1beta1 apiextensions.k8s.io/v1beta1 certmanager.k8s.io/v1alpha1 v1]
```